### PR TITLE
Replace adventureTitle with Addition key

### DIFF
--- a/MariTheButterfly/Locations/MariEventAddition.json
+++ b/MariTheButterfly/Locations/MariEventAddition.json
@@ -1,6 +1,6 @@
 {
     "name": "Mystic Forest",
-    "exploreTitle": "Addition",
+    "Addition": "Yes",
     "Monsters": [ ""],
     "MonsterGroups": [
 


### PR DESCRIPTION
Replaces adventureTitle: Addition with Addition: Yes in order to prevent the location being treated as a new one when loading and the game crashing as there is no Eros key.